### PR TITLE
Fix typo in Footer

### DIFF
--- a/website/src/lib/Footer.svelte
+++ b/website/src/lib/Footer.svelte
@@ -1,6 +1,6 @@
 <footer class="p-10 footer bg-base-200 text-base-content footer-center">
     <div class="grid grid-flow-col gap-4">
-        <a class="link-hover" rel="nofollow" href="/register">Sig up</a>
+        <a class="link-hover" rel="nofollow" href="/register">Sign up</a>
         <a class="link-hover" rel="nofollow" href="/contact">Contact</a>
         <a href="https://tasks.mawoka.eu.org/share/MeVpuBCleKDvOarUaqnMOlYSdrICNipaxcAGHlvD/auth" rel="nofollow" target="_blank" class="link-hover">Roadmap</a>
     </div>


### PR DESCRIPTION
There is a typo in the footer. This fixes it. :wink: 

![grafik](https://user-images.githubusercontent.com/8432168/151680580-d68d84d6-9660-417c-9341-d965cd32bb30.png)

By the way: this project looks really cool! :+1: 